### PR TITLE
Allow sending media metadata

### DIFF
--- a/src/cast/proxies.rs
+++ b/src/cast/proxies.rs
@@ -75,7 +75,112 @@ pub mod media {
         #[serde(rename = "contentId")] pub content_id: String,
         #[serde(rename = "streamType", default)] pub stream_type: String,
         #[serde(rename = "contentType")] pub content_type: String,
+        #[serde(skip_serializing_if = "Option::is_none")] pub metadata: Option<Metadata>,
         #[serde(skip_serializing_if = "Option::is_none")] pub duration: Option<f32>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct Metadata {
+        #[serde(rename = "metadataType")]
+        pub metadata_type: u32,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub title: Option<String>,
+
+        #[serde(skip_serializing_if = "Option::is_none", rename = "seriesTitle")]
+        pub series_title: Option<String>,
+
+        #[serde(skip_serializing_if = "Option::is_none", rename = "albumName")]
+        pub album_name: Option<String>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub subtitle: Option<String>,
+
+        #[serde(skip_serializing_if = "Option::is_none", rename = "albumArtist")]
+        pub album_artist: Option<String>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub artist: Option<String>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub composer: Option<String>,
+
+        pub images: Vec<Image>,
+
+        #[serde(skip_serializing_if = "Option::is_none", rename = "releaseDate")]
+        pub release_date: Option<String>,
+
+        #[serde(skip_serializing_if = "Option::is_none", rename = "originalAirDate")]
+        pub original_air_date: Option<String>,
+
+        #[serde(skip_serializing_if = "Option::is_none", rename = "creationDateTime")]
+        pub creation_date_time: Option<String>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub studio: Option<String>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub location: Option<String>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub latitude: Option<f64>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub longitude: Option<f64>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub season: Option<u32>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub episode: Option<u32>,
+
+        #[serde(skip_serializing_if = "Option::is_none", rename = "trackNumber")]
+        pub track_number: Option<u32>,
+
+        #[serde(skip_serializing_if = "Option::is_none", rename = "discNumber")]
+        pub disc_number: Option<u32>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub width: Option<u32>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub height: Option<u32>,
+    }
+
+    impl Metadata {
+        pub fn new(metadata_type: u32) -> Metadata {
+            Metadata {
+                metadata_type: metadata_type,
+                title: None,
+                series_title: None,
+                album_name: None,
+                subtitle: None,
+                album_artist: None,
+                artist: None,
+                composer: None,
+                images: Vec::new(),
+                release_date: None,
+                original_air_date: None,
+                creation_date_time: None,
+                studio: None,
+                location: None,
+                latitude: None,
+                longitude: None,
+                season: None,
+                episode: None,
+                track_number: None,
+                disc_number: None,
+                width: None,
+                height: None,
+            }
+        }
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct Image {
+        pub url: String,
+        #[serde(skip_serializing_if = "Option::is_none")] pub width: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")] pub height: Option<u32>,
     }
 
     #[derive(Serialize, Debug)]

--- a/src/channels/media.rs
+++ b/src/channels/media.rs
@@ -546,9 +546,9 @@ where
                 artist: x.artist.clone(),
                 location: x.location.clone(),
                 latitude: x.latitude_longitude.map(|coord| coord.0),
-                longitude: x.latitude_longitude.map(|coord| coord.0),
+                longitude: x.latitude_longitude.map(|coord| coord.1),
                 width: x.dimensions.map(|dims| dims.0),
-                height: x.dimensions.map(|dims| dims.0),
+                height: x.dimensions.map(|dims| dims.1),
                 creation_date_time: x.creation_date_time.clone(),
                 .. proxies::media::Metadata::new(4)
             },

--- a/src/channels/media.rs
+++ b/src/channels/media.rs
@@ -60,6 +60,144 @@ impl ToString for StreamType {
     }
 }
 
+/// Generic, movie, TV show, music track, or photo metadata.
+#[derive(Debug)]
+pub enum Metadata {
+    Generic(GenericMediaMetadata),
+    Movie(MovieMediaMetadata),
+    TvShow(TvShowMediaMetadata),
+    MusicTrack(MusicTrackMediaMetadata),
+    Photo(PhotoMediaMetadata),
+}
+
+/// Generic media metadata.
+///
+/// See also https://developers.google.com/cast/docs/reference/messages#GenericMediaMetadata.
+#[derive(Debug)]
+pub struct GenericMediaMetadata {
+    /// Descriptive title of the content.
+    pub title: Option<String>,
+    /// Descriptive subtitle of the content.
+    pub subtitle: Option<String>,
+    /// Zero or more URLs to an image associated with the content.
+    pub images: Vec<Image>,
+    /// Date and time the content was released, formatted as ISO 8601.
+    pub release_date: Option<String>,
+}
+
+/// Movie media metadata.
+///
+/// See also https://developers.google.com/cast/docs/reference/messages#MovieMediaMetadata.
+#[derive(Debug)]
+pub struct MovieMediaMetadata {
+    /// Title of the movie.
+    pub title: Option<String>,
+    /// Subtitle of the movie.
+    pub subtitle: Option<String>,
+    /// Studio which released the movie.
+    pub studio: Option<String>,
+    /// Zero or more URLs to an image associated with the content.
+    pub images: Vec<Image>,
+    /// Date and time the movie was released, formatted as ISO 8601.
+    pub release_date: Option<String>,
+}
+
+/// TV show media metadata.
+///
+/// See also https://developers.google.com/cast/docs/reference/messages#TvShowMediaMetadata.
+#[derive(Debug)]
+pub struct TvShowMediaMetadata {
+    /// Title of the TV series.
+    pub series_title: Option<String>,
+    /// Title of the episode.
+    pub episode_title: Option<String>,
+    /// Season number of the TV show.
+    pub season: Option<u32>,
+    /// Episode number (in the season) of the episode.
+    pub episode: Option<u32>,
+    /// Zero or more URLs to an image associated with the content.
+    pub images: Vec<Image>,
+    /// Date and time this episode was released, formatted as ISO 8601.
+    pub original_air_date: Option<String>,
+}
+
+/// Music track media metadata.
+///
+/// See also https://developers.google.com/cast/docs/reference/messages#MusicTrackMediaMetadata.
+#[derive(Debug)]
+pub struct MusicTrackMediaMetadata {
+    /// Album or collection from which the track is taken.
+    pub album_name: Option<String>,
+    /// Name of the track (for example, song title).
+    pub title: Option<String>,
+    /// Name of the artist associated with the album featuring this track.
+    pub album_artist: Option<String>,
+    /// Name of the artist associated with the track.
+    pub artist: Option<String>,
+    /// Name of the composer associated with the track.
+    pub composer: Option<String>,
+    /// Number of the track on the album.
+    pub track_number: Option<u32>,
+    /// Number of the volume (for example, a disc) of the album.
+    pub disc_number: Option<u32>,
+    /// Zero or more URLs to an image associated with the content.
+    pub images: Vec<Image>,
+    /// Date and time the content was released, formatted as ISO 8601.
+    pub release_date: Option<String>,
+}
+
+/// Photo media metadata.
+///
+/// See also https://developers.google.com/cast/docs/reference/messages#PhotoMediaMetadata.
+#[derive(Debug)]
+pub struct PhotoMediaMetadata {
+    /// Title of the photograph.
+    pub title: Option<String>,
+    /// Name of the photographer.
+    pub artist: Option<String>,
+    /// Verbal location where the photograph was taken, for example “Madrid, Spain”.
+    pub location: Option<String>,
+    /// Latitude and longitude of the location where the photograph was taken.
+    pub latitude_longitude: Option<(f64, f64)>,
+    /// Width and height of the photograph in pixels.
+    pub dimensions: Option<(u32, u32)>,
+    /// Date and time the photograph was taken, formatted as ISO 8601.
+    pub creation_date_time: Option<String>,
+}
+
+/// Image URL and optionally size metadata.
+///
+/// This is the description of an image, including a small amount of metadata to
+/// allow the sender application a choice of images, depending on how it will
+/// render them. The height and width are optional on only one item in an array
+/// of images.
+///
+/// See also https://developers.google.com/cast/docs/reference/messages#Image.
+#[derive(Debug)]
+pub struct Image {
+    /// URL of the image.
+    pub url: String,
+    /// Width and height of the image.
+    pub dimensions: Option<(u32, u32)>,
+}
+
+impl Image {
+    pub fn new(url: String) -> Image {
+        Image {
+            url: url,
+            dimensions: None,
+        }
+    }
+
+    fn encode(&self) -> proxies::media::Image {
+        proxies::media::Image {
+            url: self.url.clone(),
+            width: self.dimensions.map(|d| d.0),
+            height: self.dimensions.map(|d| d.1),
+        }
+    }
+}
+
 /// Describes possible player states.
 #[derive(Debug)]
 pub enum PlayerState {
@@ -173,6 +311,8 @@ pub struct Media {
     pub stream_type: StreamType,
     /// MIME content type of the media being played.
     pub content_type: String,
+    /// Generic, movie, TV show, music track, or photo metadata.
+    pub metadata: Option<Metadata>,
     /// Duration of the currently playing stream in seconds.
     pub duration: Option<f32>,
 }
@@ -364,6 +504,56 @@ where
     {
         let request_id = self.message_manager.generate_request_id();
 
+        let metadata = media.metadata.as_ref().map(|m| match *m {
+            Metadata::Generic(ref x) => proxies::media::Metadata {
+                title: x.title.clone(),
+                subtitle: x.subtitle.clone(),
+                images: x.images.iter().map(|i| i.encode()).collect(),
+                release_date: x.release_date.clone(),
+                .. proxies::media::Metadata::new(0)
+            },
+            Metadata::Movie(ref x) => proxies::media::Metadata {
+                title: x.title.clone(),
+                subtitle: x.subtitle.clone(),
+                studio: x.studio.clone(),
+                images: x.images.iter().map(|i| i.encode()).collect(),
+                release_date: x.release_date.clone(),
+                .. proxies::media::Metadata::new(1)
+            },
+            Metadata::TvShow(ref x) => proxies::media::Metadata {
+                series_title: x.series_title.clone(),
+                subtitle: x.episode_title.clone(),
+                season: x.season,
+                episode: x.episode,
+                images: x.images.iter().map(|i| i.encode()).collect(),
+                original_air_date: x.original_air_date.clone(),
+                .. proxies::media::Metadata::new(2)
+            },
+            Metadata::MusicTrack(ref x) => proxies::media::Metadata {
+                album_name: x.album_name.clone(),
+                title: x.title.clone(),
+                album_artist: x.album_artist.clone(),
+                artist: x.artist.clone(),
+                composer: x.composer.clone(),
+                track_number: x.track_number,
+                disc_number: x.disc_number,
+                images: x.images.iter().map(|i| i.encode()).collect(),
+                release_date: x.release_date.clone(),
+                .. proxies::media::Metadata::new(3)
+            },
+            Metadata::Photo(ref x) => proxies::media::Metadata {
+                title: x.title.clone(),
+                artist: x.artist.clone(),
+                location: x.location.clone(),
+                latitude: x.latitude_longitude.map(|coord| coord.0),
+                longitude: x.latitude_longitude.map(|coord| coord.0),
+                width: x.dimensions.map(|dims| dims.0),
+                height: x.dimensions.map(|dims| dims.0),
+                creation_date_time: x.creation_date_time.clone(),
+                .. proxies::media::Metadata::new(4)
+            },
+        });
+
         let payload = serde_json::to_string(&proxies::media::MediaRequest {
             request_id: request_id,
             session_id: session_id.into().to_string(),
@@ -373,6 +563,7 @@ where
                 content_id: media.content_id.clone(),
                 stream_type: media.stream_type.to_string(),
                 content_type: media.content_type.clone(),
+                metadata: metadata,
                 duration: media.duration,
             },
 
@@ -621,6 +812,7 @@ where
                                 content_id: m.content_id.to_string(),
                                 stream_type: StreamType::from_str(m.stream_type.as_ref()).unwrap(),
                                 content_type: m.content_type.to_string(),
+                                metadata: None, // TODO
                                 duration: m.duration,
                             }
                         }),

--- a/src/channels/media.rs
+++ b/src/channels/media.rs
@@ -72,7 +72,7 @@ pub enum Metadata {
 
 /// Generic media metadata.
 ///
-/// See also https://developers.google.com/cast/docs/reference/messages#GenericMediaMetadata.
+/// See also the [`GenericMediaMetadata` Cast reference](https://developers.google.com/cast/docs/reference/messages#GenericMediaMetadata).
 #[derive(Debug)]
 pub struct GenericMediaMetadata {
     /// Descriptive title of the content.
@@ -87,7 +87,7 @@ pub struct GenericMediaMetadata {
 
 /// Movie media metadata.
 ///
-/// See also https://developers.google.com/cast/docs/reference/messages#MovieMediaMetadata.
+/// See also the [`MovieMediaMetadata` Cast reference](https://developers.google.com/cast/docs/reference/messages#MovieMediaMetadata).
 #[derive(Debug)]
 pub struct MovieMediaMetadata {
     /// Title of the movie.
@@ -104,7 +104,7 @@ pub struct MovieMediaMetadata {
 
 /// TV show media metadata.
 ///
-/// See also https://developers.google.com/cast/docs/reference/messages#TvShowMediaMetadata.
+/// See also the [`TvShowMediaMetadata` Cast reference](https://developers.google.com/cast/docs/reference/messages#TvShowMediaMetadata).
 #[derive(Debug)]
 pub struct TvShowMediaMetadata {
     /// Title of the TV series.
@@ -123,7 +123,7 @@ pub struct TvShowMediaMetadata {
 
 /// Music track media metadata.
 ///
-/// See also https://developers.google.com/cast/docs/reference/messages#MusicTrackMediaMetadata.
+/// See also the [`MusicTrackMediaMetadata` Cast reference](https://developers.google.com/cast/docs/reference/messages#MusicTrackMediaMetadata).
 #[derive(Debug)]
 pub struct MusicTrackMediaMetadata {
     /// Album or collection from which the track is taken.
@@ -148,7 +148,7 @@ pub struct MusicTrackMediaMetadata {
 
 /// Photo media metadata.
 ///
-/// See also https://developers.google.com/cast/docs/reference/messages#PhotoMediaMetadata.
+/// See also the [`PhotoMediaMetadata` Cast reference](https://developers.google.com/cast/docs/reference/messages#PhotoMediaMetadata).
 #[derive(Debug)]
 pub struct PhotoMediaMetadata {
     /// Title of the photograph.
@@ -172,7 +172,7 @@ pub struct PhotoMediaMetadata {
 /// render them. The height and width are optional on only one item in an array
 /// of images.
 ///
-/// See also https://developers.google.com/cast/docs/reference/messages#Image.
+/// See also the [`Image` Cast reference](https://developers.google.com/cast/docs/reference/messages#Image).
 #[derive(Debug)]
 pub struct Image {
     /// URL of the image.


### PR DESCRIPTION
This defines the structs, and an encoder, but not yet a decoder. This allows sending metadata such as track title and album art with media.

Most of the fields map directly to those as specified [in the reference](https://developers.google.com/cast/docs/reference/messages), but some fields have been merged to take advantage of Rust's type system. For example, it does not make sense to provide a latitude for a photograph, but not a longitude. For clarity, the `subtitle` field of a TV show was renamed to `episode_title`.

This is a breaking change as it adds a new field. It is easy to upgrade, by setting it to `None`. This would break `rust-caster` if merged, as `rust-caster` does not pin the commit it depends on.

I am unable to check if this breaks any tests, as I was not able to compile the tests on master.