### PR TITLE
Extend StatusEntry.supported_media_commands from u8 to u32.

### DIFF
--- a/src/cast/proxies.rs
+++ b/src/cast/proxies.rs
@@ -264,7 +264,7 @@ pub mod media {
         #[serde(rename = "currentTime")]
         pub current_time: Option<f32>,
         #[serde(rename = "supportedMediaCommands")]
-        pub supported_media_commands: u8,
+        pub supported_media_commands: u32,
     }
 
     #[derive(Deserialize, Debug)]

--- a/src/channels/media.rs
+++ b/src/channels/media.rs
@@ -355,9 +355,12 @@ pub struct StatusEntry {
     /// * `4` `Stream volume`;
     /// * `8` `Stream mute`;
     /// * `16` `Skip forward`;
-    /// * `32` `Skip backward`.
+    /// * `32` `Skip backward`;
+    /// * `1 << 12` `Unknown`;
+    /// * `1 << 13` `Unknown`;
+    /// * `1 << 18` `Unknown`.
     /// Combinations are described as summations; for example, Pause+Seek+StreamVolume+Mute == 15.
-    pub supported_media_commands: u8,
+    pub supported_media_commands: u32,
 }
 
 /// Describes the load cancelled error.


### PR DESCRIPTION
Cast devices started to return supportedMediaCommand with high
bits set which won't fit into u8. Trying to parse media status messages
would therefor return Err(..).

Fixes #5.