### PR TITLE
Queue load

### DIFF
--- a/src/cast/proxies.rs
+++ b/src/cast/proxies.rs
@@ -38,6 +38,8 @@ pub mod media {
         pub media_session_id: Option<i32>,
     }
 
+    // Really LoadRequest
+    /// https://developers.google.com/cast/docs/reference/web_sender/chrome.cast.media.LoadRequest
     #[derive(Serialize, Debug)]
     pub struct MediaRequest {
         #[serde(rename = "requestId")]
@@ -58,6 +60,57 @@ pub mod media {
         pub custom_data: CustomData,
 
         pub autoplay: bool,
+    }
+
+    /// https://developers.google.com/cast/docs/reference/web_sender/chrome.cast.media.QueueItem
+    #[derive(Serialize, Debug)]
+    pub struct QueueItem {
+        #[serde(rename = "activeTrackIds")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub active_track_ids: Option<Vec<u16>>,
+
+        pub autoplay: bool,
+
+        #[serde(rename = "customData")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub custom_data: Option<CustomData>,
+
+        #[serde(rename = "itemId")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub item_id: Option<u16>,
+
+        pub media: Media,
+
+        #[serde(rename = "playbackDuration")]
+        pub playback_duration: Option<f64>,
+
+        #[serde(rename = "preloadTime")]
+        pub preload_time: f64,
+
+        #[serde(rename = "startTime")]
+        pub start_time: f64,
+    }
+
+    /// https://developers.google.com/cast/docs/reference/web_sender/chrome.cast.media.QueueLoadRequest
+    #[derive(Serialize, Debug)]
+    pub struct QueueLoadRequest {
+        #[serde(rename = "type")]
+        pub typ: String,
+
+        #[serde(rename = "requestId")]
+        pub request_id: i32,
+
+        #[serde(rename = "customData")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub custom_data: Option<CustomData>,
+
+        pub items: Vec<QueueItem>,
+
+        #[serde(rename = "repeatMode")]
+        pub repeat_mode: String,
+
+        #[serde(rename = "startIndex")]
+        pub start_index: u16,
     }
 
     #[derive(Serialize, Debug)]

--- a/src/cast/proxies.rs
+++ b/src/cast/proxies.rs
@@ -106,6 +106,11 @@ pub mod media {
 
         pub items: Vec<QueueItem>,
 
+        // This is from https://developers.google.com/cast/docs/reference/web_sender/chrome.cast.media.QueueData
+        #[serde(rename = "queueType")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub queue_type: Option<String>,
+
         #[serde(rename = "repeatMode")]
         pub repeat_mode: String,
 

--- a/src/cast/proxies.rs
+++ b/src/cast/proxies.rs
@@ -321,6 +321,12 @@ pub mod media {
         pub playback_rate: f32,
         #[serde(rename = "playerState")]
         pub player_state: String,
+        #[serde(rename = "currentItemId")]
+        pub current_item_id: Option<u16>,
+        #[serde(rename = "loadingItemId")]
+        pub loading_item_id: Option<u16>,
+        #[serde(rename = "preloadedItemId")]
+        pub preloaded_item_id: Option<u16>,
         #[serde(rename = "idleReason")]
         pub idle_reason: Option<String>,
         #[serde(rename = "extendedStatus")]

--- a/src/cast/proxies.rs
+++ b/src/cast/proxies.rs
@@ -60,6 +60,9 @@ pub mod media {
         pub custom_data: CustomData,
 
         pub autoplay: bool,
+
+        #[serde(rename = "queueData", skip_serializing_if = "Option::is_none")]
+        pub queue_data: Option<QueueData>,
     }
 
     /// https://developers.google.com/cast/docs/reference/web_sender/chrome.cast.media.QueueItem
@@ -98,7 +101,7 @@ pub mod media {
         pub typ: String,
 
         #[serde(rename = "requestId")]
-        pub request_id: i32,
+        pub request_id: u32,
 
         #[serde(rename = "customData")]
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -107,6 +110,22 @@ pub mod media {
         pub items: Vec<QueueItem>,
 
         // This is from https://developers.google.com/cast/docs/reference/web_sender/chrome.cast.media.QueueData
+        #[serde(rename = "queueType")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub queue_type: Option<String>,
+
+        #[serde(rename = "repeatMode")]
+        pub repeat_mode: String,
+
+        #[serde(rename = "startIndex")]
+        pub start_index: u16,
+    }
+
+    /// https://developers.google.com/cast/docs/reference/web_sender/chrome.cast.media.QueueData
+    #[derive(Serialize, Debug)]
+    pub struct QueueData {
+        pub items: Vec<QueueItem>,
+
         #[serde(rename = "queueType")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub queue_type: Option<String>,

--- a/src/cast/proxies.rs
+++ b/src/cast/proxies.rs
@@ -303,6 +303,15 @@ pub mod media {
     }
 
     #[derive(Deserialize, Debug)]
+    pub struct ExtendedStatus {
+        #[serde(rename = "playerState")]
+        pub player_state: String,
+        #[serde(rename = "mediaSessionId")]
+        pub media_session_id: Option<i32>,
+        pub media: Option<Media>,
+    }
+
+    #[derive(Deserialize, Debug)]
     pub struct Status {
         #[serde(rename = "mediaSessionId")]
         pub media_session_id: i32,
@@ -314,6 +323,8 @@ pub mod media {
         pub player_state: String,
         #[serde(rename = "idleReason")]
         pub idle_reason: Option<String>,
+        #[serde(rename = "extendedStatus")]
+        pub extended_status: Option<ExtendedStatus>,
         #[serde(rename = "currentTime")]
         pub current_time: Option<f32>,
         #[serde(rename = "supportedMediaCommands")]

--- a/src/channels/media.rs
+++ b/src/channels/media.rs
@@ -130,7 +130,7 @@ impl Metadata {
 /// Generic media metadata.
 ///
 /// See also the [`GenericMediaMetadata` Cast reference](https://developers.google.com/cast/docs/reference/messages#GenericMediaMetadata).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct GenericMediaMetadata {
     /// Descriptive title of the content.
     pub title: Option<String>,
@@ -145,7 +145,7 @@ pub struct GenericMediaMetadata {
 /// Movie media metadata.
 ///
 /// See also the [`MovieMediaMetadata` Cast reference](https://developers.google.com/cast/docs/reference/messages#MovieMediaMetadata).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MovieMediaMetadata {
     /// Title of the movie.
     pub title: Option<String>,
@@ -162,7 +162,7 @@ pub struct MovieMediaMetadata {
 /// TV show media metadata.
 ///
 /// See also the [`TvShowMediaMetadata` Cast reference](https://developers.google.com/cast/docs/reference/messages#TvShowMediaMetadata).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct TvShowMediaMetadata {
     /// Title of the TV series.
     pub series_title: Option<String>,
@@ -181,7 +181,7 @@ pub struct TvShowMediaMetadata {
 /// Music track media metadata.
 ///
 /// See also the [`MusicTrackMediaMetadata` Cast reference](https://developers.google.com/cast/docs/reference/messages#MusicTrackMediaMetadata).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MusicTrackMediaMetadata {
     /// Album or collection from which the track is taken.
     pub album_name: Option<String>,
@@ -206,7 +206,7 @@ pub struct MusicTrackMediaMetadata {
 /// Photo media metadata.
 ///
 /// See also the [`PhotoMediaMetadata` Cast reference](https://developers.google.com/cast/docs/reference/messages#PhotoMediaMetadata).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PhotoMediaMetadata {
     /// Title of the photograph.
     pub title: Option<String>,

--- a/src/channels/media.rs
+++ b/src/channels/media.rs
@@ -443,6 +443,21 @@ pub struct QueueItem {
     pub media: Media,
 }
 
+impl QueueItem {
+    fn encode(&self) -> proxies::media::QueueItem {
+        proxies::media::QueueItem {
+            active_track_ids: None,
+            autoplay: true,
+            custom_data: None,
+            item_id: None,
+            media: self.media.encode(),
+            playback_duration: None,
+            preload_time: 20.,
+            start_time: 0.,
+        }
+    }
+}
+
 /// A queue of items to play in sequence
 #[derive(Clone, Debug)]
 pub struct MediaQueue {
@@ -453,6 +468,17 @@ pub struct MediaQueue {
     pub start_index: u16,
     /// What the queue represents
     pub queue_type: QueueType,
+}
+
+impl MediaQueue {
+    fn encode(&self) -> proxies::media::QueueData {
+        proxies::media::QueueData {
+            items: self.items.iter().map(|qi| qi.encode()).collect(),
+            queue_type: Some(self.queue_type.to_string()),
+            repeat_mode: "REPEAT_OFF".to_owned(),
+            start_index: self.start_index,
+        }
+    }
 }
 
 /// Describes the current status of the media artifact with respect to the session.
@@ -647,6 +673,29 @@ where
     where
         S: Into<Cow<'a, str>>,
     {
+        self.load_with_queue(destination, session_id, media, None)
+    }
+
+    /// Loads provided media to the application.
+    ///
+    /// # Arguments
+    /// * `destination` - `protocol` of the application to load media with (e.g. `web-1`);
+    /// * `session_id` - Current session identifier of the player application;
+    /// * `media` - `Media` instance that describes the media we'd like to load.
+    ///
+    /// # Return value
+    ///
+    /// Returned `Result` should consist of either `Status` instance or an `Error`.
+    pub fn load_with_queue<S>(
+        &self,
+        destination: S,
+        session_id: S,
+        media: &Media,
+        queue: Option<&MediaQueue>,
+    ) -> Result<Status, Error>
+    where
+        S: Into<Cow<'a, str>>,
+    {
         let request_id = self.message_manager.generate_request_id().get();
 
         let payload = serde_json::to_string(&proxies::media::MediaRequest {
@@ -659,6 +708,7 @@ where
             current_time: 0_f64,
             autoplay: true,
             custom_data: proxies::media::CustomData::new(),
+            queue_data: queue.map(|qd| qd.encode()),
         })?;
 
         self.message_manager.send(CastMessage {
@@ -741,26 +791,13 @@ where
     where
         S: Into<Cow<'a, str>>,
     {
-        let request_id = self.message_manager.generate_request_id();
+        let request_id = self.message_manager.generate_request_id().get();
 
         let payload = serde_json::to_string(&proxies::media::QueueLoadRequest {
             typ: MESSAGE_TYPE_QUEUE_LOAD.to_string(),
             request_id,
             custom_data: None,
-            items: queue
-                .items
-                .iter()
-                .map(|qi| proxies::media::QueueItem {
-                    active_track_ids: None,
-                    autoplay: true,
-                    custom_data: None,
-                    item_id: None,
-                    media: qi.media.encode(),
-                    playback_duration: None,
-                    preload_time: 20.,
-                    start_time: 0.,
-                })
-                .collect(),
+            items: queue.items.iter().map(|qi| qi.encode()).collect(),
             queue_type: Some(queue.queue_type.to_string()),
             repeat_mode: "REPEAT_OFF".to_owned(),
             start_index: queue.start_index,

--- a/src/channels/media.rs
+++ b/src/channels/media.rs
@@ -323,6 +323,55 @@ impl FromStr for IdleReason {
     }
 }
 
+/// <https://developers.google.com/cast/docs/reference/web_sender/chrome.cast.media#.QueueType>
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum QueueType {
+    Album,
+    Playlist,
+    Audiobook,
+    RadioStation,
+    PodcastSeries,
+    TvSeries,
+    VideoPlaylist,
+    LiveTv,
+    Movie,
+}
+
+impl FromStr for QueueType {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "ALBUM" => Ok(Self::Album),
+            "PLAYLIST" => Ok(Self::Playlist),
+            "AUDIOBOOK" => Ok(Self::Audiobook),
+            "RADIO_STATION" => Ok(Self::RadioStation),
+            "PODCAST_SERIES" => Ok(Self::PodcastSeries),
+            "TV_SERIES" => Ok(Self::TvSeries),
+            "VIDEO_PLAYLIST" => Ok(Self::VideoPlaylist),
+            "LIVE_TV" => Ok(Self::LiveTv),
+            "MOVIE" => Ok(Self::Movie),
+            _ => Err(Error::Internal(format!("Unknown queue type {}", s))),
+        }
+    }
+}
+
+impl ToString for QueueType {
+    fn to_string(&self) -> String {
+        match self {
+            QueueType::Album => "ALBUM",
+            QueueType::Playlist => "PLAYLIST",
+            QueueType::Audiobook => "AUDIOBOOK",
+            QueueType::RadioStation => "RADIO_STATION",
+            QueueType::PodcastSeries => "PODCAST_SERIES",
+            QueueType::TvSeries => "TV_SERIES",
+            QueueType::VideoPlaylist => "VIDEO_PLAYLIST",
+            QueueType::LiveTv => "LIVE_TV",
+            QueueType::Movie => "MOVIE",
+        }
+        .to_string()
+    }
+}
+
 /// Describes the operation to perform with playback while seeking.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ResumeState {
@@ -402,6 +451,8 @@ pub struct MediaQueue {
     /// Array index of the first item to be played
     /// Starts at zero.
     pub start_index: u16,
+    /// What the queue represents
+    pub queue_type: QueueType,
 }
 
 /// Describes the current status of the media artifact with respect to the session.
@@ -710,6 +761,7 @@ where
                     start_time: 0.,
                 })
                 .collect(),
+            queue_type: Some(queue.queue_type.to_string()),
             repeat_mode: "REPEAT_OFF".to_owned(),
             start_index: queue.start_index,
         })?;

--- a/src/channels/media.rs
+++ b/src/channels/media.rs
@@ -28,7 +28,7 @@ const MESSAGE_TYPE_INVALID_PLAYER_STATE: &str = "INVALID_PLAYER_STATE";
 const MESSAGE_TYPE_INVALID_REQUEST: &str = "INVALID_REQUEST";
 
 /// Describes the way cast device should stream content.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum StreamType {
     /// This variant allows cast device to automatically choose whatever way it's most comfortable
     /// with.
@@ -256,7 +256,7 @@ impl Image {
 }
 
 /// Describes possible player states.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum PlayerState {
     /// Player has not been loaded yet.
     Idle,
@@ -296,7 +296,7 @@ impl ToString for PlayerState {
 }
 
 /// Describes possible player idle reasons.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum IdleReason {
     /// A sender requested to stop playback using the STOP command.
     Cancelled,
@@ -324,7 +324,7 @@ impl FromStr for IdleReason {
 }
 
 /// Describes the operation to perform with playback while seeking.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ResumeState {
     /// Forces media to start.
     PlaybackStart,

--- a/src/channels/media.rs
+++ b/src/channels/media.rs
@@ -662,6 +662,12 @@ pub struct StatusEntry {
     pub playback_rate: f32,
     /// Describes the state of the player.
     pub player_state: PlayerState,
+    /// Id of the current queue item
+    pub current_item_id: Option<u16>,
+    /// Id of the item currently loading
+    pub loading_item_id: Option<u16>,
+    /// Id of the item currently preloaded
+    pub preloaded_item_id: Option<u16>,
     /// If the player_state is IDLE and the reason it became IDLE is known, this property is
     /// provided. If the player is IDLE because it just started, this property will not be provided.
     /// If the player is in any other state this property should not be provided.
@@ -696,6 +702,9 @@ impl TryFrom<&proxies::media::Status> for StatusEntry {
             media: x.media.as_ref().map(TryInto::try_into).transpose()?,
             playback_rate: x.playback_rate,
             player_state: PlayerState::from_str(x.player_state.as_ref())?,
+            current_item_id: x.current_item_id,
+            loading_item_id: x.loading_item_id,
+            preloaded_item_id: x.preloaded_item_id,
             idle_reason: x
                 .idle_reason
                 .as_ref()

--- a/src/channels/media.rs
+++ b/src/channels/media.rs
@@ -16,6 +16,7 @@ const CHANNEL_NAMESPACE: &str = "urn:x-cast:com.google.cast.media";
 
 const MESSAGE_TYPE_GET_STATUS: &str = "GET_STATUS";
 const MESSAGE_TYPE_LOAD: &str = "LOAD";
+const MESSAGE_TYPE_QUEUE_LOAD: &str = "QUEUE_LOAD";
 const MESSAGE_TYPE_PLAY: &str = "PLAY";
 const MESSAGE_TYPE_PAUSE: &str = "PAUSE";
 const MESSAGE_TYPE_STOP: &str = "STOP";
@@ -70,6 +71,60 @@ pub enum Metadata {
     TvShow(TvShowMediaMetadata),
     MusicTrack(MusicTrackMediaMetadata),
     Photo(PhotoMediaMetadata),
+}
+
+impl Metadata {
+    fn encode(&self) -> proxies::media::Metadata {
+        match self {
+            Metadata::Generic(ref x) => proxies::media::Metadata {
+                title: x.title.clone(),
+                subtitle: x.subtitle.clone(),
+                images: x.images.iter().map(|i| i.encode()).collect(),
+                release_date: x.release_date.clone(),
+                ..proxies::media::Metadata::new(0)
+            },
+            Metadata::Movie(ref x) => proxies::media::Metadata {
+                title: x.title.clone(),
+                subtitle: x.subtitle.clone(),
+                studio: x.studio.clone(),
+                images: x.images.iter().map(|i| i.encode()).collect(),
+                release_date: x.release_date.clone(),
+                ..proxies::media::Metadata::new(1)
+            },
+            Metadata::TvShow(ref x) => proxies::media::Metadata {
+                series_title: x.series_title.clone(),
+                subtitle: x.episode_title.clone(),
+                season: x.season,
+                episode: x.episode,
+                images: x.images.iter().map(|i| i.encode()).collect(),
+                original_air_date: x.original_air_date.clone(),
+                ..proxies::media::Metadata::new(2)
+            },
+            Metadata::MusicTrack(ref x) => proxies::media::Metadata {
+                album_name: x.album_name.clone(),
+                title: x.title.clone(),
+                album_artist: x.album_artist.clone(),
+                artist: x.artist.clone(),
+                composer: x.composer.clone(),
+                track_number: x.track_number,
+                disc_number: x.disc_number,
+                images: x.images.iter().map(|i| i.encode()).collect(),
+                release_date: x.release_date.clone(),
+                ..proxies::media::Metadata::new(3)
+            },
+            Metadata::Photo(ref x) => proxies::media::Metadata {
+                title: x.title.clone(),
+                artist: x.artist.clone(),
+                location: x.location.clone(),
+                latitude: x.latitude_longitude.map(|coord| coord.0),
+                longitude: x.latitude_longitude.map(|coord| coord.1),
+                width: x.dimensions.map(|dims| dims.0),
+                height: x.dimensions.map(|dims| dims.1),
+                creation_date_time: x.creation_date_time.clone(),
+                ..proxies::media::Metadata::new(4)
+            },
+        }
+    }
 }
 
 /// Generic media metadata.
@@ -318,6 +373,37 @@ pub struct Media {
     pub duration: Option<f32>,
 }
 
+impl Media {
+    fn encode(&self) -> proxies::media::Media {
+        let metadata = self.metadata.as_ref().map(|m| m.encode());
+
+        proxies::media::Media {
+            content_id: self.content_id.clone(),
+            stream_type: self.stream_type.to_string(),
+            content_type: self.content_type.clone(),
+            metadata,
+            duration: self.duration,
+        }
+    }
+}
+
+/// One item in a queue
+#[derive(Clone, Debug)]
+pub struct QueueItem {
+    /// The item as media
+    pub media: Media,
+}
+
+/// A queue of items to play in sequence
+#[derive(Clone, Debug)]
+pub struct MediaQueue {
+    /// Every item in the queue, in order
+    pub items: Vec<QueueItem>,
+    /// Array index of the first item to be played
+    /// Starts at zero.
+    pub start_index: u16,
+}
+
 /// Describes the current status of the media artifact with respect to the session.
 #[derive(Clone, Debug)]
 pub struct Status {
@@ -512,68 +598,12 @@ where
     {
         let request_id = self.message_manager.generate_request_id().get();
 
-        let metadata = media.metadata.as_ref().map(|m| match *m {
-            Metadata::Generic(ref x) => proxies::media::Metadata {
-                title: x.title.clone(),
-                subtitle: x.subtitle.clone(),
-                images: x.images.iter().map(|i| i.encode()).collect(),
-                release_date: x.release_date.clone(),
-                ..proxies::media::Metadata::new(0)
-            },
-            Metadata::Movie(ref x) => proxies::media::Metadata {
-                title: x.title.clone(),
-                subtitle: x.subtitle.clone(),
-                studio: x.studio.clone(),
-                images: x.images.iter().map(|i| i.encode()).collect(),
-                release_date: x.release_date.clone(),
-                ..proxies::media::Metadata::new(1)
-            },
-            Metadata::TvShow(ref x) => proxies::media::Metadata {
-                series_title: x.series_title.clone(),
-                subtitle: x.episode_title.clone(),
-                season: x.season,
-                episode: x.episode,
-                images: x.images.iter().map(|i| i.encode()).collect(),
-                original_air_date: x.original_air_date.clone(),
-                ..proxies::media::Metadata::new(2)
-            },
-            Metadata::MusicTrack(ref x) => proxies::media::Metadata {
-                album_name: x.album_name.clone(),
-                title: x.title.clone(),
-                album_artist: x.album_artist.clone(),
-                artist: x.artist.clone(),
-                composer: x.composer.clone(),
-                track_number: x.track_number,
-                disc_number: x.disc_number,
-                images: x.images.iter().map(|i| i.encode()).collect(),
-                release_date: x.release_date.clone(),
-                ..proxies::media::Metadata::new(3)
-            },
-            Metadata::Photo(ref x) => proxies::media::Metadata {
-                title: x.title.clone(),
-                artist: x.artist.clone(),
-                location: x.location.clone(),
-                latitude: x.latitude_longitude.map(|coord| coord.0),
-                longitude: x.latitude_longitude.map(|coord| coord.1),
-                width: x.dimensions.map(|dims| dims.0),
-                height: x.dimensions.map(|dims| dims.1),
-                creation_date_time: x.creation_date_time.clone(),
-                ..proxies::media::Metadata::new(4)
-            },
-        });
-
         let payload = serde_json::to_string(&proxies::media::MediaRequest {
             request_id,
             session_id: session_id.into().to_string(),
             typ: MESSAGE_TYPE_LOAD.to_string(),
 
-            media: proxies::media::Media {
-                content_id: media.content_id.clone(),
-                stream_type: media.stream_type.to_string(),
-                content_type: media.content_type.clone(),
-                metadata,
-                duration: media.duration,
-            },
+            media: media.encode(),
 
             current_time: 0_f64,
             autoplay: true,
@@ -614,6 +644,93 @@ where
                     };
 
                     if has_media {
+                        return Ok(Some(status));
+                    }
+                }
+                MediaResponse::LoadFailed(error) => {
+                    if error.request_id == request_id {
+                        return Err(Error::Internal("Failed to load media.".to_string()));
+                    }
+                }
+                MediaResponse::LoadCancelled(error) => {
+                    if error.request_id == request_id {
+                        return Err(Error::Internal(
+                            "Load cancelled by another request.".to_string(),
+                        ));
+                    }
+                }
+                MediaResponse::InvalidPlayerState(error) => {
+                    if error.request_id == request_id {
+                        return Err(Error::Internal(
+                            "Load failed because of invalid player state.".to_string(),
+                        ));
+                    }
+                }
+                MediaResponse::InvalidRequest(error) => {
+                    if error.request_id == request_id {
+                        return Err(Error::Internal(format!(
+                            "Load failed because of invalid media request (reason: {}).",
+                            error.reason.unwrap_or_else(|| "UNKNOWN".to_string())
+                        )));
+                    }
+                }
+                _ => {}
+            }
+
+            Ok(None)
+        })
+    }
+
+    pub fn load_queue<S>(
+        &self,
+        destination: S,
+        _session_id: S,
+        queue: &MediaQueue,
+    ) -> Result<Status, Error>
+    where
+        S: Into<Cow<'a, str>>,
+    {
+        let request_id = self.message_manager.generate_request_id();
+
+        let payload = serde_json::to_string(&proxies::media::QueueLoadRequest {
+            typ: MESSAGE_TYPE_QUEUE_LOAD.to_string(),
+            request_id,
+            custom_data: None,
+            items: queue
+                .items
+                .iter()
+                .map(|qi| proxies::media::QueueItem {
+                    active_track_ids: None,
+                    autoplay: true,
+                    custom_data: None,
+                    item_id: None,
+                    media: qi.media.encode(),
+                    playback_duration: None,
+                    preload_time: 20.,
+                    start_time: 0.,
+                })
+                .collect(),
+            repeat_mode: "REPEAT_OFF".to_owned(),
+            start_index: queue.start_index,
+        })?;
+
+        self.message_manager.send(CastMessage {
+            namespace: CHANNEL_NAMESPACE.to_string(),
+            source: self.sender.to_string(),
+            destination: destination.into().to_string(),
+            payload: CastMessagePayload::String(payload),
+        })?;
+
+        // Once media is loaded cast receiver device should emit status update event, or load failed
+        // event if something went wrong.
+        self.message_manager.receive_find_map(|message| {
+            if !self.can_handle(message) {
+                return Ok(None);
+            }
+
+            match self.parse(message)? {
+                MediaResponse::Status(status) => {
+                    if status.request_id == request_id {
                         return Ok(Some(status));
                     }
                 }

--- a/src/channels/media.rs
+++ b/src/channels/media.rs
@@ -295,6 +295,38 @@ impl ToString for PlayerState {
     }
 }
 
+/// Describes possible player states.
+/// Can appear when the base state is PlayerState::Idle
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ExtendedPlayerState {
+    /// Player is loading the next media
+    Loading,
+}
+
+impl FromStr for ExtendedPlayerState {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "LOADING" => Ok(Self::Loading),
+            _ => Err(Error::Internal(format!(
+                "Unknown extended player state {}",
+                s
+            ))),
+        }
+    }
+}
+
+impl ToString for ExtendedPlayerState {
+    fn to_string(&self) -> String {
+        let player_state = match *self {
+            Self::Loading => "LOADING",
+        };
+
+        player_state.to_string()
+    }
+}
+
 /// Describes possible player idle reasons.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum IdleReason {
@@ -436,6 +468,18 @@ impl Media {
     }
 }
 
+impl From<&proxies::media::Media> for Media {
+    fn from(m: &proxies::media::Media) -> Self {
+        Self {
+            content_id: m.content_id.to_string(),
+            stream_type: StreamType::from_str(m.stream_type.as_ref()).unwrap(),
+            content_type: m.content_type.to_string(),
+            metadata: None, // TODO
+            duration: m.duration,
+        }
+    }
+}
+
 /// One item in a queue
 #[derive(Clone, Debug)]
 pub struct QueueItem {
@@ -490,6 +534,20 @@ pub struct Status {
     pub entries: Vec<StatusEntry>,
 }
 
+/// Status of loading the next media
+#[derive(Clone, Debug)]
+pub struct ExtendedStatus {
+    /// Describes the state of the player.
+    pub player_state: ExtendedPlayerState,
+    /// Unique ID for the playback of this specific session. This ID is set by the receiver at LOAD
+    /// and can be used to identify a specific instance of a playback. For example, two playbacks of
+    /// "Wish you were here" within the same session would each have a unique mediaSessionId.
+    pub media_session_id: Option<i32>,
+    /// Full description of the content that is being played back. Only be returned in a status
+    /// messages if the Media has changed.
+    pub media: Option<Media>,
+}
+
 /// Detailed status of the media artifact with respect to the session.
 #[derive(Clone, Debug)]
 pub struct StatusEntry {
@@ -510,6 +568,9 @@ pub struct StatusEntry {
     /// provided. If the player is IDLE because it just started, this property will not be provided.
     /// If the player is in any other state this property should not be provided.
     pub idle_reason: Option<IdleReason>,
+    /// An extended status can be used when the player is idle (no playback) but also loading
+    /// another media.
+    pub extended_status: Option<ExtendedStatus>,
     /// The current position of the media player since the beginning of the content, in seconds.
     /// If this a live stream content, then this field represents the time in seconds from the
     /// beginning of the event that should be known to the player.
@@ -1032,27 +1093,22 @@ where
             MESSAGE_TYPE_MEDIA_STATUS => {
                 let reply: proxies::media::StatusReply = serde_json::value::from_value(reply)?;
 
-                let statuses_entries = reply.status.iter().map(|x| {
-                    StatusEntry {
-                        media_session_id: x.media_session_id,
-                        media: x.media.as_ref().map(|m| {
-                            Media {
-                                content_id: m.content_id.to_string(),
-                                stream_type: StreamType::from_str(m.stream_type.as_ref()).unwrap(),
-                                content_type: m.content_type.to_string(),
-                                metadata: None, // TODO
-                                duration: m.duration,
-                            }
-                        }),
-                        playback_rate: x.playback_rate,
-                        player_state: PlayerState::from_str(x.player_state.as_ref()).unwrap(),
-                        idle_reason: x
-                            .idle_reason
-                            .as_ref()
-                            .map(|reason| IdleReason::from_str(reason).unwrap()),
-                        current_time: x.current_time,
-                        supported_media_commands: x.supported_media_commands,
-                    }
+                let statuses_entries = reply.status.iter().map(|x| StatusEntry {
+                    media_session_id: x.media_session_id,
+                    media: x.media.as_ref().map(|m| m.into()),
+                    playback_rate: x.playback_rate,
+                    player_state: PlayerState::from_str(x.player_state.as_ref()).unwrap(),
+                    idle_reason: x
+                        .idle_reason
+                        .as_ref()
+                        .map(|reason| IdleReason::from_str(reason).unwrap()),
+                    extended_status: x.extended_status.as_ref().map(|es| ExtendedStatus {
+                        player_state: ExtendedPlayerState::from_str(&es.player_state).unwrap(),
+                        media_session_id: es.media_session_id,
+                        media: es.media.as_ref().map(|m| m.into()),
+                    }),
+                    current_time: x.current_time,
+                    supported_media_commands: x.supported_media_commands,
                 });
 
                 MediaResponse::Status(Status {

--- a/src/channels/media.rs
+++ b/src/channels/media.rs
@@ -127,6 +127,75 @@ impl Metadata {
     }
 }
 
+impl TryFrom<&proxies::media::Metadata> for Metadata {
+    type Error = Error;
+
+    fn try_from(m: &proxies::media::Metadata) -> Result<Self, Error> {
+        Ok(match m.metadata_type {
+            0 => Self::Generic(GenericMediaMetadata {
+                title: m.title.clone(),
+                subtitle: m.subtitle.clone(),
+                images: m.images.iter().map(Image::from).collect(),
+                release_date: m.release_date.clone(),
+            }),
+            1 => Self::Movie(MovieMediaMetadata {
+                title: m.title.clone(),
+                subtitle: m.subtitle.clone(),
+                studio: m.studio.clone(),
+                images: m.images.iter().map(Image::from).collect(),
+                release_date: m.release_date.clone(),
+            }),
+            2 => Self::TvShow(TvShowMediaMetadata {
+                series_title: m.series_title.clone(),
+                episode_title: m.subtitle.clone(),
+                season: m.season,
+                episode: m.episode,
+                images: m.images.iter().map(Image::from).collect(),
+                original_air_date: m.original_air_date.clone(),
+            }),
+            3 => Self::MusicTrack(MusicTrackMediaMetadata {
+                album_name: m.album_name.clone(),
+                title: m.title.clone(),
+                album_artist: m.album_artist.clone(),
+                artist: m.artist.clone(),
+                composer: m.composer.clone(),
+                track_number: m.track_number,
+                disc_number: m.disc_number,
+                images: m.images.iter().map(Image::from).collect(),
+                release_date: m.release_date.clone(),
+            }),
+            4 => {
+                let mut dimensions = None;
+                let mut latitude_longitude = None;
+                if let Some(width) = m.width {
+                    if let Some(height) = m.height {
+                        dimensions = Some((width, height))
+                    }
+                }
+                if let Some(lat) = m.latitude {
+                    if let Some(long) = m.longitude {
+                        latitude_longitude = Some((lat, long))
+                    }
+                }
+                Self::Photo(PhotoMediaMetadata {
+                    title: m.title.clone(),
+                    artist: m.artist.clone(),
+                    location: m.location.clone(),
+                    latitude_longitude,
+                    dimensions,
+                    creation_date_time: m.creation_date_time.clone(),
+                })
+            }
+            _ => {
+                return Err(Error::Parsing(format!(
+                    "Bad metadataType {}",
+                    m.metadata_type
+                )))
+            }
+        })
+    }
+}
+
 /// Generic media metadata.
 ///
 /// See also the [`GenericMediaMetadata` Cast reference](https://developers.google.com/cast/docs/reference/messages#GenericMediaMetadata).
@@ -251,6 +320,21 @@ impl Image {
             url: self.url.clone(),
             width: self.dimensions.map(|d| d.0),
             height: self.dimensions.map(|d| d.1),
+        }
+    }
+}
+
+impl From<&proxies::media::Image> for Image {
+    fn from(i: &proxies::media::Image) -> Self {
+        let mut dimensions = None;
+        if let Some(width) = i.width {
+            if let Some(height) = i.height {
+                dimensions = Some((width, height));
+            }
+        };
+        Self {
+            url: i.url.clone(),
+            dimensions,
         }
     }
 }
@@ -468,15 +552,17 @@ impl Media {
     }
 }
 
-impl From<&proxies::media::Media> for Media {
-    fn from(m: &proxies::media::Media) -> Self {
-        Self {
+impl TryFrom<&proxies::media::Media> for Media {
+    type Error = Error;
+
+    fn try_from(m: &proxies::media::Media) -> Result<Self, Error> {
+        Ok(Self {
             content_id: m.content_id.to_string(),
-            stream_type: StreamType::from_str(m.stream_type.as_ref()).unwrap(),
+            stream_type: StreamType::from_str(m.stream_type.as_ref())?,
             content_type: m.content_type.to_string(),
-            metadata: None, // TODO
+            metadata: m.metadata.as_ref().map(TryInto::try_into).transpose()?,
             duration: m.duration,
-        }
+        })
     }
 }
 
@@ -548,6 +634,18 @@ pub struct ExtendedStatus {
     pub media: Option<Media>,
 }
 
+impl TryFrom<&proxies::media::ExtendedStatus> for ExtendedStatus {
+    type Error = Error;
+
+    fn try_from(es: &proxies::media::ExtendedStatus) -> Result<Self, Error> {
+        Ok(Self {
+            player_state: ExtendedPlayerState::from_str(&es.player_state)?,
+            media_session_id: es.media_session_id,
+            media: es.media.as_ref().map(Media::try_from).transpose()?,
+        })
+    }
+}
+
 /// Detailed status of the media artifact with respect to the session.
 #[derive(Clone, Debug)]
 pub struct StatusEntry {
@@ -587,6 +685,31 @@ pub struct StatusEntry {
     /// * `1 << 18` `Unknown`.
     /// Combinations are described as summations; for example, Pause+Seek+StreamVolume+Mute == 15.
     pub supported_media_commands: u32,
+}
+
+impl TryFrom<&proxies::media::Status> for StatusEntry {
+    type Error = Error;
+
+    fn try_from(x: &proxies::media::Status) -> Result<Self, Error> {
+        Ok(Self {
+            media_session_id: x.media_session_id,
+            media: x.media.as_ref().map(TryInto::try_into).transpose()?,
+            playback_rate: x.playback_rate,
+            player_state: PlayerState::from_str(x.player_state.as_ref())?,
+            idle_reason: x
+                .idle_reason
+                .as_ref()
+                .map(|reason| IdleReason::from_str(reason))
+                .transpose()?,
+            extended_status: x
+                .extended_status
+                .as_ref()
+                .map(ExtendedStatus::try_from)
+                .transpose()?,
+            current_time: x.current_time,
+            supported_media_commands: x.supported_media_commands,
+        })
+    }
 }
 
 /// Describes the load cancelled error.
@@ -1093,27 +1216,15 @@ where
             MESSAGE_TYPE_MEDIA_STATUS => {
                 let reply: proxies::media::StatusReply = serde_json::value::from_value(reply)?;
 
-                let statuses_entries = reply.status.iter().map(|x| StatusEntry {
-                    media_session_id: x.media_session_id,
-                    media: x.media.as_ref().map(|m| m.into()),
-                    playback_rate: x.playback_rate,
-                    player_state: PlayerState::from_str(x.player_state.as_ref()).unwrap(),
-                    idle_reason: x
-                        .idle_reason
-                        .as_ref()
-                        .map(|reason| IdleReason::from_str(reason).unwrap()),
-                    extended_status: x.extended_status.as_ref().map(|es| ExtendedStatus {
-                        player_state: ExtendedPlayerState::from_str(&es.player_state).unwrap(),
-                        media_session_id: es.media_session_id,
-                        media: es.media.as_ref().map(|m| m.into()),
-                    }),
-                    current_time: x.current_time,
-                    supported_media_commands: x.supported_media_commands,
-                });
+                let entries = reply
+                    .status
+                    .iter()
+                    .map(StatusEntry::try_from)
+                    .collect::<Result<_, _>>()?;
 
                 MediaResponse::Status(Status {
                     request_id: reply.request_id,
-                    entries: statuses_entries.collect::<Vec<StatusEntry>>(),
+                    entries,
                 })
             }
             MESSAGE_TYPE_LOAD_CANCELLED => {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,9 +16,11 @@ pub enum Error {
     Io(IoError),
     /// This variant includes all possible errors that come from Protobuf layer.
     Protobuf(ProtobufError),
-    /// This variant includes everything related to (de)serialization of incoming and outgoing
+    /// Errors with JSON (de)serialization of incoming and outgoing
     /// messages.
     Serialization(SerializationError),
+    /// Errors parsing messages (valid JSON but bad semantics)
+    Parsing(String),
     /// This variant is used to indicate invalid DNS name used to connect to Cast device.
     Dns(InvalidDnsNameError),
     /// This variant includes any error that comes from rustls.
@@ -34,6 +36,7 @@ impl Display for Error {
             Error::Io(ref err) => Display::fmt(&err, f),
             Error::Protobuf(ref err) => Display::fmt(&err, f),
             Error::Serialization(ref err) => Display::fmt(&err, f),
+            Error::Parsing(ref message) => f.write_str(message),
             Error::Tls(ref err) => Display::fmt(&err, f),
             Error::Dns(ref err) => Display::fmt(&err, f),
             Error::Namespace(ref err) => Display::fmt(&err, f),
@@ -50,6 +53,7 @@ impl StdError for Error {
             Error::Dns(ref err) => Some(err),
             Error::Serialization(ref err) => Some(err),
             Error::Internal(_) => None,
+            Error::Parsing(_) => None,
             Error::Namespace(_) => None,
         }
     }


### PR DESCRIPTION
I've added various features, mostly relating to queues, serializing and deserializing media messages in more detail.
Three commits add queue-related commands or fields to commands, three commits improve status deserialisation (including removing all uses of unwrap in that area), two commits add impls of common traits to public media types.

Looking at the new extended statuses, I've stayed close to the message format, but it might be more user-friendly to add extended states to the original PlayerState enum; the next release will already break compat by adding stuff to the error enum anyway.