### PR TITLE
Fix compiling in nightly

### DIFF
--- a/src/cast/authority_keys.rs
+++ b/src/cast/authority_keys.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/src/cast/cast_channel.rs
+++ b/src/cast/cast_channel.rs
@@ -9,7 +9,6 @@
 #![allow(unused_attributes)]
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]


### PR DESCRIPTION
In nightly, the compiler complains about the `box_pointers` lint:
```
error: lint `box_pointers` has been removed: it does not detect other kinds of allocations, and existed only for historical reasons
  --> src\cast\cast_channel.rs:12:10
   |
12 | #![allow(box_pointers)]
   |
```
It was removed [4 months ago](https://github.com/rust-lang/rust/actions/runs/9392282401).
This PR removes this lint from both cast_channel.rs and authority_keys.rs.